### PR TITLE
do not persist password in memory during lifetime of the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-ircbot
-======
+# ircbot
 
 Simple irc bot package in Go
 
 Example of implementation can be found at ttps://github.com/zaibon/zbibot
 
-##installation
+## Installation
+
 ````bash
 go get github.com/zaibon/ircbot
 ````
 
-##usage
-````go
+## Usage
+
+```go
 import (
 	"github.com/zaibon/ircbot"
 	"github.com/zaibon/ircbot/actions"
@@ -23,7 +24,7 @@ func main(){
 	channels := string[]{
 		"go-nuts",
 	}
-	b := ircbot.NewIrcBot("ircbot", "ircbot", "password", "irc.freenode.net", "6667", channels, "irc.db")
+	b := ircbot.NewIrcBot("ircbot", "ircbot", "irc.freenode.net", "6667", channels, "irc.db")
 
 	//add custom intern actions
 	b.AddInternAction(&actions.Greet{})
@@ -35,11 +36,10 @@ func main(){
 	b.AddUserAction(&actions.Help{})
 
 	//connectin to server, listen and serve
-	b.Connect()
+	b.Connect(os.Getenv("MY_PASSWORD"))
 
 	//block until we send something to b.Exit channel
 	<-b.Exit
+	b.Disconnect()
 }
-
-b.Disconnect()
-````
+```

--- a/actions/test_test.go
+++ b/actions/test_test.go
@@ -26,14 +26,14 @@ func initActionnerTest(t *testing.T) (*textproto.Reader, *textproto.Writer, net.
 	}
 	fmt.Printf("test server listen on %s\n", ln.Addr().String())
 
-	b := ircbot.NewIrcBot("testBot", "testBot", "", "127.0.0.1", 3333, []string{"#test"}, "irc_test.db")
+	b := ircbot.NewIrcBot("testBot", "testBot", "127.0.0.1", 3333, []string{"#test"}, "irc_test.db")
 	b.AddInternAction(&Greet{})
 	b.AddInternAction(NewURLLog(b))
 	b.AddInternAction(NewTitleExtract())
 	b.AddUserAction(&Ping{})
 	b.AddUserAction(NewURL(b))
 
-	b.Connect()
+	b.Connect("")
 
 	fmt.Printf("test server waiting connection...\n")
 	conn, err := ln.Accept()

--- a/bot.go
+++ b/bot.go
@@ -21,9 +21,8 @@ import (
 // IrcBot represents the bot in general
 type IrcBot struct {
 	// identity
-	User     string
-	Nick     string
-	password string
+	User string
+	Nick string
 
 	// server info
 	server   string
@@ -62,11 +61,10 @@ type IrcBot struct {
 	db *db.DB
 }
 
-func NewIrcBot(user, nick, password, server string, port uint, channels []string, DBPath string) *IrcBot {
+func NewIrcBot(user, nick, server string, port uint, channels []string, DBPath string) *IrcBot {
 	bot := IrcBot{
 		User:     user,
 		Nick:     nick,
-		password: password,
 		server:   server,
 		port:     port,
 		channels: channels,
@@ -97,7 +95,7 @@ func NewIrcBot(user, nick, password, server string, port uint, channels []string
 /////////////////
 
 // Connect connects the bot to the server and joins the channels
-func (b *IrcBot) Connect() error {
+func (b *IrcBot) Connect(password string) error {
 	//launch a go routine that handle errors
 	// b.handleError()
 
@@ -140,7 +138,7 @@ func (b *IrcBot) Connect() error {
 	b.handleActionOut()
 	b.handlerError()
 
-	b.identify()
+	b.identify(password)
 
 	return nil
 }
@@ -239,10 +237,10 @@ func (b *IrcBot) join() {
 	}
 }
 
-func (b *IrcBot) identify() {
+func (b *IrcBot) identify(password string) {
 	//idenify with nickserv
-	if b.password != "" {
-		s := fmt.Sprintf("PRIVMSG NickServ :identify %s %s", b.Nick, b.password)
+	if password != "" {
+		s := fmt.Sprintf("PRIVMSG NickServ :identify %s %s", b.Nick, password)
 		log.WithFields(log.Fields{
 			"nick":   b.Nick,
 			"passwd": "*****",
@@ -250,7 +248,6 @@ func (b *IrcBot) identify() {
 		b.writer.PrintfLine(s)
 	}
 }
-
 func (b *IrcBot) listen() {
 
 	go func() {


### PR DESCRIPTION
instead just pass it as an argument to the Identify method.

By a proposal of @mindfarm in https://github.com/zaibon/ircbot/issues/2

closes #2 